### PR TITLE
Updating Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let WdioTestRailReporter = require('wdio-testrail-custom-reporter');
 
 
 Mark your mocha test names with ID of Testrail test cases. Ensure that your case ids are well distinct from test descriptions.
- 
+
 ```Javascript
 it("C123 Authenticate with invalid user", . . .
 it("Authenticate a valid user C321", . . .
@@ -56,6 +56,8 @@ Only passed or failed tests will be published. Skipped or pending tests will not
 **assignedToId**: *number* (optional) user id which will be assigned failed tests
 
 **includeAllTest**: *number* (optional) default true, if false only tests that were ran with show within test run on TestRail
+
+**errorshotHost**: *string* (optional) default null, if provided then screenshot names will be appended to host and included in reports (check [wdio-screenshot-uploader-service](https://www.npmjs.com/package/wdio-screenshot-uploader-service) for more details)
 
 ## Automatic creation of sections and cases
 You can use next command to generate sections/cases based on your tests in test real:
@@ -115,3 +117,4 @@ If your test descriptions ever change just re-run the comman to update the testc
 - https://www.npmjs.com/package/mocha-testrail-reporter
 - http://webdriver.io/guide/reporters/customreporter.html
 - http://docs.gurock.com/testrail-api2/start
+- https://www.npmjs.com/package/wdio-screenshot-uploader-service

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,39 @@
+ /**
+  * By using the information provided by a capability object,
+  * a string is returned that includes the browser, its'
+  * version and which platform it is on.
+  *
+  * @param {object} caps
+  * @param {boolean} verbose
+  * @return {string}
+  */
+ function getBrowserCombo(caps, verbose = true) {
+    const device = caps.deviceName || '';
+    const browser = caps.browserName || caps.browser;
+    const version = caps.version || caps.platformVersion || caps.browser_version;
+    const platform = caps.os ? (caps.os + ' ' + caps.os_version) : (caps.platform || caps.platformName);
+
+    /**
+     * mobile capabilities
+     */
+    if (device) {
+        const program = (caps.app || '').replace('sauce-storage:', '') || caps.browserName;
+        const executing = program ? `executing ${program}` : '';
+
+        if (!verbose) {
+            return `${device} ${platform} ${version}`;
+        }
+
+        return `${device} on ${platform} ${version} ${executing}`.trim();
+    }
+
+    if (!verbose) {
+        return (browser + ' ' + (version || '') + ' ' + (platform || '')).trim();
+    }
+
+    return browser + (version ? ` (v${version})` : '') + (platform ? ` on ${platform}` : '');
+}
+
+module.exports = {
+   getBrowserCombo
+};

--- a/lib/test-rail.js
+++ b/lib/test-rail.js
@@ -1,4 +1,5 @@
 const request = require("sync-request");
+const helpers = require('./helpers');
 
 /**
  * TestRail basic API wrapper
@@ -104,6 +105,19 @@ class TestRail {
     }
 
     /**
+	 * Creates a new array of unique data from the data
+	 * within 2 existing arrays
+	 *
+	 * @param {Array.<*>} currArr
+	 * @param {Array.<*>} newArr
+	 * @returns {array}
+	 * @private
+	 */
+	_createUniqueArray(currArr, newArr) {
+		return [...new Set([...newArr, ...currArr])]
+	}
+
+    /**
      * @param {string} title
      * @param {number|null} parentId
      * @return {{id}}
@@ -126,13 +140,13 @@ class TestRail {
         return this._get(`get_sections/${this.options.projectId}&suite_id=${this.options.suiteId}`);
     }
 
-    /** 
+    /**
      * @return {[]}
      */
     getCases() {
         return this._get(`get_cases/${this.options.projectId}\&suite_id=${this.options.suiteId}`);
     }
-  
+
       /**
        * @return {[]}
        */
@@ -142,6 +156,89 @@ class TestRail {
       };
         return this._post(`update_case/${case_id}`, body);
     }
+
+    /**
+	 * Creates a new test plan
+	 *
+	 * @param {string} name - Plan name
+	 * @param {string} desc - Plane description
+	 * @param {Array.<Object>} testRuns - Test runs
+	 * @returns {*} API response
+	 */
+	addPlan(name, description, testRuns) {
+		return this._post(`add_plan/${this.options.projectId}`, {
+			"name": name,
+			"description": description,
+			"entries": testRuns
+		});
+    }
+
+    /**
+	 * Retrieves a test plan
+	 *
+	 * @param {number} planId - Plan identifier
+	 * @returns {*} API response
+	 */
+	getPlan(planId) {
+		return this._get(`get_plan/${this.options.updatePlan}`);
+    }
+
+    /**
+	 * Adds a test plan entry to the current project
+	 *
+	 * @param {number} planId - Plan identifier
+	 * @param {number} suiteId  - Suite identifier
+	 * @param {string} name - Plan name
+	 * @param {string} desc - Plan name
+	 * @param {Array.<Object>} runs - Test runs
+	 * @param {Array.<number>} caseIds - Test case identifiers
+	 * @return {*} API response
+	 */
+	addTestPlanEntry(planId, suiteId, name, desc, runs, caseIds) {
+		return this._post(
+			`add_plan_entry/${planId}`, {
+				'include_all': this.options.includeAllTest,
+				'suite_id': suiteId,
+				'name': name,
+				'description': desc,
+				'runs': runs,
+				'case_ids': caseIds
+			});
+    }
+
+    /**
+	 * Adds missing case ids to a test plan entry
+	 *
+	 * @param {number} planId - Plan identifier
+	 * @param {number} entryId  - Entry identifier
+	 * @param {Array.<number>} caseIds - Test case identifiers
+	 * @return {*} API response
+	 */
+	updateTestPlanEntry(planId, entryId, caseIds) {
+		return this._post(`update_plan_entry/${planId}/${entryId}`, {
+			case_ids: caseIds
+		});
+    }
+
+    /**
+	 * Gets a suite
+	 *
+	 * @param {number} suiteId - Suite identifier
+	 * @return {*} API response
+	 */
+	getSuite(suiteId) {
+		return this._get(`get_suite/${suiteId}`);
+    }
+
+    /**
+	 * Gets all the tests in a run
+	 *
+	 * @param {number} runId - Run identifier
+	 * @return {*} API response
+	 */
+	getTestsForRun(runId) {
+		return this._get(`get_tests/${runId}`)
+	}
 
     /**
      * @param {string} title
@@ -154,37 +251,48 @@ class TestRail {
         });
     }
 
+	/**
+	 * Adds a test run
+	 *
+	 * @param {string} name - Test run name
+	 * @param {string} description - Test run description
+	 * @param {number} suiteId - Suite id for test cases in this run
+	 * @return {*} API response
+	 */
+	addRun(name, description, suiteId, caseIds) {
+		return this._post(`add_run/${this.options.projectId}`, {
+			"suite_id": suiteId,
+			"name": name,
+			"description": description,
+			"assignedto_id": this.options.assignedToId,
+			"include_all": this.options.includeAllTest,
+			"case_ids": caseIds
+		});
+	}
+
     /**
-     * @param {string} name
-     * @param {string} description
-     * @return {*}
-     */
-    addRun(name, description, case_ids) {
-        return this._post(`add_run/${this.options.projectId}`, {
-            "suite_id": this.options.suiteId,
-            "name": name,
-            "description": description,
-            "assignedto_id": this.options.assignedToId,
-            "include_all": this.options.includeAllTest,
-            "case_ids": case_ids
-        });
+	 * Adds test cases to a test run
+	 *
+	 * @param {number} runId - Run identifier
+	 * @param {Array.<Object>} cases - Test case data
+	 * @return {*} API response
+	 */
+	addCasesToRun(runId, cases) {
+		const currentCases = this.getTestsForRun(runId).map(c => c.case_id);
+		this._post(`update_run/${runId}`, {
+			'case_ids': this._createUniqueArray(currentCases, cases)
+		});
     }
 
     /**
-     * Publishes results of execution of an automated test run
-     * @param {string} name
-     * @param {string} description
-     * @param {[]} results
-     * @param {callback} callback
-     */
-    publish(name, description, results, case_ids, callback = undefined) {
-        let run = this.addRun(name, description, case_ids);
-        console.log(`Results published to ${this.base}?/runs/view/${run.id}`);
-        let body = this.addResultsForCases(run.id, results);
-        // execute callback if specified
-        if (callback) {
-            callback(body);
-        }
+	 * Get test cases that belong to a suite
+	 *
+	 * @param {*} projectId - Project identifier
+	 * @param {*} suiteId - Suite identifier
+	 * @return {*} API response
+	 */
+	getTestsForSuite(projectId, suiteId) {
+		return this._get(`get_cases/${projectId}&suite_id=${suiteId}`);
     }
 
     /**
@@ -196,6 +304,108 @@ class TestRail {
         return this._post(`add_results_for_cases/${runId}`, {
             results: results
         });
+    }
+
+    /**
+     * Publishes results of execution of an automated test run
+     * @param {string} name
+     * @param {string} description
+     * @param {[]} results
+     * @param {callback} callback
+     */
+    publish(name, description, results, case_ids, runners ,callback = undefined) {
+        let runs = [];
+		let body = null;
+        let plan = null
+
+        if(typeof this.options.suiteId !== 'number'){
+            if (this.options.updatePlan) {
+
+                //1. find our existing plan
+				plan = this.getPlan(this.options.updatePlan);
+
+				plan.entries.forEach(entry => {
+
+					const suiteInfo = this.getSuite(entry.runs[0].suite_id);
+					const currentCases = this.getTestsForRun(entry.runs[0].id).map(c => c.case_id);
+					suiteInfo.cases = this.getTestsForSuite(this.options.projectId, suiteInfo.id).map(c => c.id);
+					suiteInfo.newCases = results.filter(r => suiteInfo.cases.includes(r.case_id));
+
+					//reset case id listing
+					this.updateTestPlanEntry(
+						plan.id,
+						entry.id,
+						this._createUniqueArray(
+							currentCases,
+							suiteInfo.newCases.map(r => r.case_id)
+						)
+					)
+					body = [];
+					//add new results
+					body.push(this.addResultsForCases(entry.runs[0].id, suiteInfo.newCases));
+				})
+            }else {
+                let testPlanEntries = []
+				//1. create the test plan
+				plan = this.addPlan(name, description, []);
+				runners.forEach((runner, runnerIdx) => {
+					this.options.suiteId.forEach((suiteId, suiteIdx) => {
+						const suiteInfo = this.getSuite(suiteId);
+						suiteInfo.cases = this.getTestsForSuite(this.options.projectId, suiteId).map(c => c.id);
+						//runs =
+						testPlanEntries.push(
+							this.addTestPlanEntry(
+								plan.id,
+								suiteId,
+								`(${helpers.getBrowserCombo(runner)})`,
+								description, [],
+								results.filter(result => {
+									return JSON.stringify(result.runner) === JSON.stringify(runner);
+                                }).map(result => result.case_id)).runs[0]);
+
+						body = [];
+
+						body.push(
+							this.addResultsForCases(
+								testPlanEntries.slice(-1)[0].id,
+								results.filter(r => suiteInfo.cases.includes(r.case_id) &&
+									JSON.stringify(r.runner) === JSON.stringify(runner))
+							)
+						);
+					})
+				})
+			}
+
+			console.log(`Results published to ${this.base}?/plans/view/${plan.id}`);
+			console.log(`Add updatePlan: ${plan.id} to your config to update this plan.`);
+        }else{
+            if(this.options.updateRun){
+                //update existing run
+				runs[0] = {
+					id: this.options.updateRun
+				};
+
+				//add any missing test case ids to a run
+				this.addCasesToRun(runs[0].id, results.map(r => r.case_id));
+            }else{
+                // add results for a run
+                runners.forEach((runner, idx) => {
+                    const runName = `${name} - (${runner.deviceName||runner.platform} - ${runner.browserName})`;
+                    runs.push(this.addRun(runName, description, this.options.suiteId, results.filter(result => {
+						return JSON.stringify(result.runner) === JSON.stringify(runner);
+                    }).map(result => result.case_id)));
+                    this.addResultsForCases(runs[idx].id, results);
+                });
+            }
+
+            console.log(`Results published to ${this.base}?/runs/view/${runs[0].id}`);
+			console.log(`Add updateRun: ${runs[0].id} to your config to update this run.`);
+        }
+
+        // execute callback if specified
+        if (callback) {
+            callback(body);
+        }
     }
 }
 

--- a/lib/wdio-testrail-custom-reporter.js
+++ b/lib/wdio-testrail-custom-reporter.js
@@ -3,6 +3,9 @@ let TestRail = require('./test-rail');
 let titleToCaseIds = require('mocha-testrail-reporter/dist/lib/shared').titleToCaseIds;
 let Status = require('mocha-testrail-reporter/dist/lib/testrail.interface').Status;
 let case_ids = [];
+let runners = {};
+
+const helpers = require('./helpers');
 
 class WdioTestRailReporter extends events.EventEmitter {
 
@@ -29,6 +32,9 @@ class WdioTestRailReporter extends events.EventEmitter {
         });
 
         this.on('test:pass', (test) => {
+            const capability = test.runner[test.cid];
+
+            this.setRunners(capability);
             this._passes++;
             this._out.push(test.title + ': pass');
             let caseIds = titleToCaseIds(test.title);
@@ -38,6 +44,7 @@ class WdioTestRailReporter extends events.EventEmitter {
                     return {
                         case_id: caseId,
                         status_id: Status.Passed,
+                        runner: capability,
                         comment: `${this.getRunComment(test)}`
                     };
                 });
@@ -49,6 +56,7 @@ class WdioTestRailReporter extends events.EventEmitter {
             const capability = test.runner[test.cid];
             const runnerInfo = baseReporter.stats.runners[test.cid];
 
+            this.setRunners(capability);
             this._fails++;
             this._out.push(test.title + ': fail');
             let caseIds = titleToCaseIds(test.title);
@@ -58,6 +66,7 @@ class WdioTestRailReporter extends events.EventEmitter {
                     return {
                         case_id: caseId,
                         status_id: Status.Failed,
+                        runner: capability,
                         comment: `${this.getRunComment(test)}
 
 **${test.err.message}**
@@ -72,7 +81,7 @@ _Additional Test Context_
 > ${this.getSessionIdOrJobLink(runnerInfo)}
 
 **Browser Info:**
-> ${this.getBrowserCombo(capability)}
+> ${helpers.getBrowserCombo(capability)}
 
 **Screenshot:**
 > ${this.getErrorShotComment(this.failureScreenshots[test.uid])}
@@ -112,7 +121,7 @@ Fails: ${this._fails}
 Pending: ${this._pending}
 Total: ${total}
 `;
-            this.testRail.publish(name, description, this._results, case_ids);
+            this.testRail.publish(name, description, this._results, case_ids, Object.values(runners));
         });
     }
 
@@ -145,6 +154,16 @@ Total: ${total}
     }
 
     /**
+     * @param {object} runner
+     */
+    setRunners(runner){
+        const runnerSring = JSON.stringify(runner);
+        if(!runner[runnerSring]){
+            runners[runnerSring] = runner;
+        }
+    }
+
+    /**
      * @param {Object} results
      * @return {string}
      */
@@ -160,37 +179,6 @@ Total: ${total}
         }else{
             return results.sessionID;
         }
-    }
-
-    /**
-     * @param {object} caps
-     * @param {boolean} verbose
-     */
-    getBrowserCombo (caps, verbose = true) {
-        const device = caps.deviceName || '';
-        const browser = caps.browserName || caps.browser;
-        const version = caps.version || caps.platformVersion || caps.browser_version;
-        const platform = caps.os ? (caps.os + ' ' + caps.os_version) : (caps.platform || caps.platformName);
-
-        /**
-         * mobile capabilities
-         */
-        if (device) {
-            const program = (caps.app || '').replace('sauce-storage:', '') || caps.browserName;
-            const executing = program ? `executing ${program}` : '';
-
-            if (!verbose) {
-                return `${device} ${platform} ${version}`;
-            }
-
-            return `${device} on ${platform} ${version} ${executing}`.trim();
-        }
-
-        if (!verbose) {
-            return (browser + ' ' + (version || '') + ' ' + (platform || '')).trim();
-        }
-
-        return browser + (version ? ` (v${version})` : '') + (platform ? ` on ${platform}` : '');
     }
 }
 

--- a/lib/wdio-testrail-custom-reporter.js
+++ b/lib/wdio-testrail-custom-reporter.js
@@ -19,6 +19,8 @@ class WdioTestRailReporter extends events.EventEmitter {
         this._fails = 0;
         this._pending = 0;
         this._out = [];
+        this.failureScreenshots = {};
+        this.errorshotHost = (config.errorshotHost || options.errorshotHost || null)
         this.testRail = new TestRail(options);
 
         this.on('test:pending', (test) => {
@@ -44,6 +46,9 @@ class WdioTestRailReporter extends events.EventEmitter {
         });
 
         this.on('test:fail', (test) => {
+            const capability = test.runner[test.cid];
+            const runnerInfo = baseReporter.stats.runners[test.cid];
+
             this._fails++;
             this._out.push(test.title + ': fail');
             let caseIds = titleToCaseIds(test.title);
@@ -54,14 +59,40 @@ class WdioTestRailReporter extends events.EventEmitter {
                         case_id: caseId,
                         status_id: Status.Failed,
                         comment: `${this.getRunComment(test)}
-${test.err.message}
-${test.err.stack}
+
+**${test.err.message}**
+
+> ${test.err.stack}
+
+----
+
+_Additional Test Context_
+
+**Session Id/Saucelabs Link:**
+> ${this.getSessionIdOrJobLink(runnerInfo)}
+
+**Browser Info:**
+> ${this.getBrowserCombo(capability)}
+
+**Screenshot:**
+> ${this.getErrorShotComment(this.failureScreenshots[test.uid])}
 `
                     };
                 });
                 this._results.push(...results);
             }
         });
+
+        this.on('runner:screenshot', (screenshot) => {
+           try {
+            if(this.errorshotHost){
+                screenshot.url =  `${this.errorshotHost}/${screenshot.filename}`;
+            }
+            this.failureScreenshots[screenshot.uid] = screenshot;
+           } catch (error) {
+               return;
+           }
+        })
 
         this.on('end', () => {
             if (this._results.length == 0) {
@@ -75,7 +106,7 @@ ${test.err.stack}
             let runName = options.runName || WdioTestRailReporter.reporterName;
             let name = `${runName}: automated test run ${executionDateTime}`;
             let description = `${name}
-Execution summary:
+**Execution summary:**
 Passes: ${this._passes}
 Fails: ${this._fails}
 Pending: ${this._pending}
@@ -86,12 +117,80 @@ Total: ${total}
     }
 
     /**
+     * @param {{filename,url}} screenshot
+     * @return {string}
+     */
+    getErrorShotComment(screenshot){
+        try {
+            if(this.errorshotHost){
+                let screenshotMdLink = `[${screenshot.filename}](${screenshot.url})`
+                return `!${screenshotMdLink}
+> ${screenshotMdLink}
+                `
+            }else {
+                return screenshot.filename;
+            }
+        } catch (error) {
+            return `No screenshot available. There was an error: ${error}`;
+        }
+    }
+
+    /**
      * @param {{title}} test
      * @return {string}
      */
     getRunComment(test) {
         let comment = test.title;
         return comment;
+    }
+
+    /**
+     * @param {Object} results
+     * @return {string}
+     */
+    getSessionIdOrJobLink (results) {
+        if (!results.config.host) {
+            return;
+        }
+
+        let jobLink = '';
+        if (results.config.host.indexOf('saucelabs.com') > -1 || results.config.sauceConnect === true) {
+            jobLink += `Check out job at https://saucelabs.com/tests/${results.sessionID}\n`;
+            return jobLink;
+        }else{
+            return results.sessionID;
+        }
+    }
+
+    /**
+     * @param {object} caps
+     * @param {boolean} verbose
+     */
+    getBrowserCombo (caps, verbose = true) {
+        const device = caps.deviceName || '';
+        const browser = caps.browserName || caps.browser;
+        const version = caps.version || caps.platformVersion || caps.browser_version;
+        const platform = caps.os ? (caps.os + ' ' + caps.os_version) : (caps.platform || caps.platformName);
+
+        /**
+         * mobile capabilities
+         */
+        if (device) {
+            const program = (caps.app || '').replace('sauce-storage:', '') || caps.browserName;
+            const executing = program ? `executing ${program}` : '';
+
+            if (!verbose) {
+                return `${device} ${platform} ${version}`;
+            }
+
+            return `${device} on ${platform} ${version} ${executing}`.trim();
+        }
+
+        if (!verbose) {
+            return (browser + ' ' + (version || '') + ' ' + (platform || '')).trim();
+        }
+
+        return browser + (version ? ` (v${version})` : '') + (platform ? ` on ${platform}` : '');
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-testrail-custom-reporter",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Testrail reporter for webdriver.io including TestRail API basic library (fork from wdio-testrail-reporter)",
   "main": "./lib/wdio-testrail-custom-reporter.js",
   "directories": {


### PR DESCRIPTION
- Supports multiple browsers - creates test plan/run 
- Support for updating results for existing plan or run. 
- Provides more details for failed tests including:
   * Session Id/Saucelabs Link
   * Browser info
   * Screenshot (if configured)
- Better formatting for error and stack-trace 
<img width="633" alt="additional test context and better formating for failed tests" src="https://user-images.githubusercontent.com/12203794/42975025-d80ba4ca-8b6e-11e8-934e-bb5b04ec745b.png">
