### PR TITLE
attaching screenshot at the end instead of during test:fail event

### DIFF
--- a/lib/wdio-testrail-custom-reporter.js
+++ b/lib/wdio-testrail-custom-reporter.js
@@ -1,3 +1,4 @@
+let path = require('path');
 let events = require('events');
 let TestRail = require('./test-rail');
 let titleToCaseIds = require('mocha-testrail-reporter/dist/lib/shared').titleToCaseIds;
@@ -64,6 +65,7 @@ class WdioTestRailReporter extends events.EventEmitter {
                 case_ids.push(...caseIds);
                 let results = caseIds.map(caseId => {
                     return {
+                        uid: test.uid,
                         case_id: caseId,
                         status_id: Status.Failed,
                         runner: capability,
@@ -82,9 +84,6 @@ _Additional Test Context_
 
 **Browser Info:**
 > ${helpers.getBrowserCombo(capability)}
-
-**Screenshot:**
-> ${this.getErrorShotComment(this.failureScreenshots[test.uid])}
 `
                     };
                 });
@@ -94,6 +93,7 @@ _Additional Test Context_
 
         this.on('runner:screenshot', (screenshot) => {
            try {
+            screenshot.filename = path.basename(screenshot.filename);
             if(this.errorshotHost){
                 screenshot.url =  `${this.errorshotHost}/${screenshot.filename}`;
             }
@@ -108,6 +108,17 @@ _Additional Test Context_
                 console.warn("No testcases were matched. Ensure that your tests are declared correctly and matches TCxxx\n" +
                     "You may use script generate-cases to do it automatically.");
                 return;
+            }else{
+                //attach screenshots to results
+                this._results.forEach((result,idx) =>{
+                    const {uid, comment} = result;
+                    if(uid){
+                        this._results[idx].comment = `${comment}
+
+**Screenshot:**
+> ${this.getErrorShotComment(this.failureScreenshots[uid])}`;
+                    }
+                });
             }
 
             let executionDateTime = new Date();


### PR DESCRIPTION
This will ensure that screenshots taken within the "afterTest" hook
will be associated to the corresponding test.